### PR TITLE
fixing readable-stream dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "sinon": "~1.7.3"
   },
   "dependencies": {
-    "readable-stream": "git://github.com/deoxxa/readable-stream#fix-issue-66"
+    "readable-stream": "~1.1.9"
   }
 }


### PR DESCRIPTION
- was pointing at no longer existing github repo
- the issue fix was merged and thus main package can be used again
